### PR TITLE
upgrade plugin to support Bitbucket 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ target/*
 .sdk/
 .sdk.tar.gz
 versions/*
+.idea/
+stashbot.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,6 @@
 language: java
 jdk:
     - oraclejdk8
-notifications:
-    irc:
-        channels:
-            - "irc.freenode.org#stashbot"
-        on_success: always
-        on_failure: always
-        use_notice: true
-        skip_join: true
 
 install: ./bin/travis-install.sh
 cache:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Stashbot
 
-Bitbucket Server 4.X Build Status: [![Build Status](https://travis-ci.org/terabyte/stashbot.svg?branch=master)](https://travis-ci.org/terabyte/stashbot)
+Dwolla has forked this plugin to upgrade it to Bitbucket 5.  Future upgrades are unlikely.  Responses to pull requests and issues may be slow.  
 
-Stash 3.X Build Status: [![Build Status](https://travis-ci.org/terabyte/stashbot.svg?branch=stash-3.x-backports)](https://travis-ci.org/terabyte/stashbot)
-
-Stashbot is a plugin designed to enable a continuous integration workflow within stash (similar to gerrit + jenkins).
+Bitbucket Server 5.X Build Status: [![Build Status](https://travis-ci.org/Dwolla/stashbot.svg?branch=master)](https://travis-ci.org/dwolla/stashbot)
 
 # INSTALL GUIDE
 

--- a/bin/install-plugin-sdk-linux.sh
+++ b/bin/install-plugin-sdk-linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Version 6.1.0
-DOWNLOAD_URL="https://marketplace.atlassian.com/download/plugins/atlassian-plugin-sdk-tgz/version/42310"
+# Version 6.3.10
+DOWNLOAD_URL="https://marketplace.atlassian.com/download/apps/1210993/version/42430"
 # To find new URLs, see: https://marketplace.atlassian.com/plugins/atlassian-plugin-sdk-tgz/versions
 
 INSTALL_BIN=`pwd`/.sdk.tar.gz

--- a/bin/travis-install.sh
+++ b/bin/travis-install.sh
@@ -6,7 +6,7 @@
 ./bin/install-plugin-sdk.sh
 
 # The maven dependencies: cache $HOME/.m2
-./bin/invoke-sdk.sh dependency:go-offline
+./bin/invoke-sdk.sh --quiet dependency:go-offline
 
 echo "Size of plugin SDK: "
 du -hs .sdk

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,12 @@
             <artifactId>gson</artifactId>
             <version>2.2.2-atlassian-1</version>
         </dependency>
+        <dependency>
+            <groupId>com.atlassian.bundles</groupId>
+            <artifactId>json</artifactId>
+            <version>20070829</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -239,15 +245,15 @@
     </build>
 
     <properties>
-        <bitbucket.version>4.1.0</bitbucket.version>
-        <bitbucket.data.version>4.1.0</bitbucket.data.version>
+        <bitbucket.version>5.8.0</bitbucket.version>
+        <bitbucket.data.version>5.8.0</bitbucket.data.version>
         <bitbucket.containerId>tomcat8x</bitbucket.containerId>
         <!--
         WARNING: manually sync this with the version in stash - variable in the
         pom has the same name but isn't imported for some reason.
          -->
         <google.guava.libversion>18.0</google.guava.libversion>
-        <plugin.testrunner.version>1.1</plugin.testrunner.version>
+        <plugin.testrunner.version>1.1.1</plugin.testrunner.version>
         <!-- TODO: I manually figured out this version - can we automatically figure it out?
              This is the version used by bitbucket 4.1.0-->
         <ao.version>1.1.3</ao.version>

--- a/src/main/java/com/palantir/stash/stashbot/hooks/TriggerJenkinsBuildHook.java
+++ b/src/main/java/com/palantir/stash/stashbot/hooks/TriggerJenkinsBuildHook.java
@@ -87,7 +87,7 @@ public class TriggerJenkinsBuildHook implements PostReceiveHook {
         // First trigger all publish builds (if they are enabled)
         if (cpm.getJobTypeStatusMapping(rc, JobType.PUBLISH)) {
             for (RefChange refChange : changes) {
-                if (!refChange.getRefId().matches(rc.getPublishBranchRegex())) {
+                if (!refChange.getRef().getId().matches(rc.getPublishBranchRegex())) {
                     continue;
                 }
 
@@ -104,7 +104,7 @@ public class TriggerJenkinsBuildHook implements PostReceiveHook {
                 // published and not verified, if the ref matches both build and verify.
                 log.info("Stashbot Trigger: Triggering PUBLISH build for commit " + refChange.getToHash());
                 // trigger a publication build
-                jenkinsManager.triggerBuild(repo, JobType.PUBLISH, refChange.getToHash(), refChange.getRefId());
+                jenkinsManager.triggerBuild(repo, JobType.PUBLISH, refChange.getToHash(), refChange.getRef().getId());
                 publishBuilds.add(refChange.getToHash());
             }
         }
@@ -141,12 +141,12 @@ public class TriggerJenkinsBuildHook implements PostReceiveHook {
 
         // now calculate the changed/added/deleted refs
         for (RefChange refChange : changes) {
-            if (!refChange.getRefId().matches(rc.getVerifyBranchRegex())) {
+            if (!refChange.getRef().getId().matches(rc.getVerifyBranchRegex())) {
                 continue;
             }
 
             // Since we are a verify branch that changed, we need to not be in minusBranches anymore
-            minusBranches.remove(refChange.getRefId());
+            minusBranches.remove(refChange.getRef().getId());
 
             switch (refChange.getType()) {
             case DELETE:

--- a/src/main/java/com/palantir/stash/stashbot/util/PullRequestCommentAddOperation.java
+++ b/src/main/java/com/palantir/stash/stashbot/util/PullRequestCommentAddOperation.java
@@ -13,26 +13,32 @@
 // limitations under the License.
 package com.palantir.stash.stashbot.util;
 
+import com.atlassian.bitbucket.comment.CommentService;
+import com.atlassian.bitbucket.pull.PullRequest;
 import com.atlassian.bitbucket.pull.PullRequestService;
 import com.atlassian.bitbucket.util.Operation;
+import com.atlassian.bitbucket.comment.AddCommentRequest.Builder;
 
 public class PullRequestCommentAddOperation implements Operation<Void, Exception> {
 
     private final PullRequestService prs;
+    private final CommentService commentService;
     private final Integer repoId;
     private final Long prId;
     private final String commentText;
 
-    public PullRequestCommentAddOperation(PullRequestService prs, Integer repoId, Long prId, String commentText) {
-        this.prs = prs;
+    public PullRequestCommentAddOperation(PullRequestService prs, CommentService commentService, Integer repoId, Long prId, String commentText) {
+        this.commentService = commentService;
         this.repoId = repoId;
         this.prId = prId;
         this.commentText = commentText;
+        this.prs = prs;
     }
 
     @Override
-    public Void perform() throws Exception {
-        prs.addComment(repoId, prId, commentText);
+    public Void perform() {
+        PullRequest pr = prs.getById(repoId, prId);
+        commentService.addComment(new Builder(pr, commentText).build());
         return null;
     }
 }

--- a/src/test/java/com/palantir/stash/stashbot/hooks/TriggerJenkinsBuildHookTest.java
+++ b/src/test/java/com/palantir/stash/stashbot/hooks/TriggerJenkinsBuildHookTest.java
@@ -16,6 +16,7 @@ package com.palantir.stash.stashbot.hooks;
 import java.sql.SQLException;
 import java.util.ArrayList;
 
+import com.atlassian.bitbucket.repository.MinimalRef;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -37,6 +38,8 @@ import com.palantir.stash.stashbot.mocks.MockGitCommandBuilderFactory;
 import com.palantir.stash.stashbot.outputhandler.CommandOutputHandlerFactory;
 import com.palantir.stash.stashbot.persistence.JenkinsServerConfiguration;
 import com.palantir.stash.stashbot.persistence.RepositoryConfiguration;
+
+import static org.mockito.Mockito.mock;
 
 public class TriggerJenkinsBuildHookTest {
 
@@ -89,11 +92,14 @@ public class TriggerJenkinsBuildHookTest {
         Mockito.when(rc.getCiEnabled()).thenReturn(true);
         Mockito.when(rc.getVerifyBranchRegex()).thenReturn(".*master.*");
         Mockito.when(rc.getPublishBranchRegex()).thenReturn(".*release.*");
+        Mockito.when(rc.getJenkinsServerName()).thenReturn("test");
         Mockito.when(jsc.getMaxVerifyChain()).thenReturn(MVC);
 
         Mockito.when(change.getFromHash()).thenReturn(FROM_HEAD);
         Mockito.when(change.getToHash()).thenReturn(HEAD);
-        Mockito.when(change.getRefId()).thenReturn(HEAD_BR);
+        MinimalRef ref = mock(MinimalRef.class);
+        Mockito.when(change.getRef()).thenReturn(ref);
+        Mockito.when(ref.getId()).thenReturn(HEAD_BR);
         Mockito.when(change.getType()).thenReturn(RefChangeType.UPDATE);
 
         changes = new ArrayList<RefChange>();


### PR DESCRIPTION
These changes should allow Stashbot to work on Bitbucket 5.

Here's Stashbot running on Bitbucket five showing a pull request that's tested
![screen shot 2018-07-25 at 10 00 11 am](https://user-images.githubusercontent.com/2546907/43226436-7e4cfe90-9021-11e8-8c4e-8300d123e5a8.png)

Here's the corresponding Jenkins jobs that Stashbot created (tested on Jenkins 1.658 won't work on Jenkins 2+)
![screen shot 2018-07-25 at 10 02 47 am](https://user-images.githubusercontent.com/2546907/43226438-7e6530e6-9021-11e8-99c6-e369d29c43ca.png)
