### PR TITLE
add additional logging to debug NullPointerException

### DIFF
--- a/src/main/java/com/palantir/stash/stashbot/servlet/RepoConfigurationServlet.java
+++ b/src/main/java/com/palantir/stash/stashbot/servlet/RepoConfigurationServlet.java
@@ -113,6 +113,23 @@ public class RepoConfigurationServlet extends HttpServlet {
                 ImmutableMap.Builder<String, String> m = ImmutableMap.builder();
                 m.put("text", jsc.getName());
                 m.put("value", jsc.getName());
+
+                String jscGetName = "undefined";
+                if (jsc != null) {
+                    jscGetName = jsc.getName();
+                }
+
+                String rcGetJenkinsServerName = "undefined";
+                if (rc != null) {
+                    rcGetJenkinsServerName = rc.getJenkinsServerName();
+                }
+
+                log.info("Printing possible causes of a NullPointerException: \n" +
+                    "    jsc: " + String.valueOf(jsc) + "\n" +
+                    "    jsc.getName(): " + String.valueOf(jscGetName) + "\n" +
+                    "    rc: " + String.valueOf(rc) + "\n" +
+                    "    rc.getJenkinsServerName(): " + String.valueOf(rcGetJenkinsServerName));
+
                 if (rc.getJenkinsServerName().equals(jsc.getName())) {
                     m.put("selected", "true");
                 }


### PR DESCRIPTION
Currently receiving a 500 when attempting to configure Stashbot for the jenkins-stack repo: https://bitbucket.dwolla.net/plugins/servlet/stashbot/repo-admin/OPS/jenkins-stack. The following exception is logged:

```
2018-11-26 20:18:12,473 ERROR [http-nio-7990-exec-22]  o.a.c.c.C.[.[.[/].[plugins] Servlet.service() for servlet [plugins] in context with path [] threw exception
java.lang.NullPointerException: null
at com.palantir.stash.stashbot.servlet.RepoConfigurationServlet.doGet(RepoConfigurationServlet.java:116)
at com.atlassian.applinks.core.rest.context.ContextFilter.doFilter(ContextFilter.java:24)
last message repeated 4 times
at com.atlassian.analytics.client.filter.UniversalAnalyticsFilter.doFilter(UniversalAnalyticsFilter.java:92)
at com.atlassian.analytics.client.filter.AbstractHttpFilter.doFilter(AbstractHttpFilter.java:39)
at com.atlassian.stash.internal.spring.lifecycle.LifecycleJohnsonServletFilterModuleContainerFilter.doFilter(LifecycleJohnsonServletFilterModuleContainerFilter.java:42)
at com.opensymphony.sitemesh.webapp.SiteMeshFilter.obtainContent(SiteMeshFilter.java:181)
at com.opensymphony.sitemesh.webapp.SiteMeshFilter.doFilter(SiteMeshFilter.java:85)
at com.atlassian.plugin.connect.plugin.auth.scope.ApiScopingFilter.doFilter(ApiScopingFilter.java:81)
at com.atlassian.stash.internal.spring.lifecycle.LifecycleJohnsonServletFilterModuleContainerFilter.doFilter(LifecycleJohnsonServletFilterModuleContainerFilter.java:42)
at com.atlassian.stash.internal.spring.security.StashAuthenticationFilter.doFilter(StashAuthenticationFilter.java:85)
at com.atlassian.stash.internal.web.auth.BeforeLoginPluginAuthenticationFilter.doInsideSpringSecurityChain(BeforeLoginPluginAuthenticationFilter.java:112)
at com.atlassian.stash.internal.web.auth.BeforeLoginPluginAuthenticationFilter.doFilter(BeforeLoginPluginAuthenticationFilter.java:75)
at com.atlassian.security.auth.trustedapps.filter.TrustedApplicationsFilter.doFilter(TrustedApplicationsFilter.java:94)
at com.atlassian.oauth.serviceprovider.internal.servlet.OAuthFilter.doFilter(OAuthFilter.java:67)
at com.atlassian.stash.internal.spring.lifecycle.LifecycleJohnsonServletFilterModuleContainerFilter.doFilter(LifecycleJohnsonServletFilterModuleContainerFilter.java:42)
at com.atlassian.plugin.connect.plugin.auth.oauth2.DefaultSalAuthenticationFilter.doFilter(DefaultSalAuthenticationFilter.java:69)
at com.atlassian.plugin.connect.plugin.auth.user.ThreeLeggedAuthFilter.doFilter(ThreeLeggedAuthFilter.java:109)
at com.atlassian.jwt.internal.servlet.JwtAuthFilter.doFilter(JwtAuthFilter.java:32)
at com.atlassian.analytics.client.filter.DefaultAnalyticsFilter.doFilter(DefaultAnalyticsFilter.java:38)
```

Adding this additional logging should help in debugging the cause of the issue.